### PR TITLE
Prevent logs from being index by search engines.

### DIFF
--- a/views/layouts/default.ctp
+++ b/views/layouts/default.ctp
@@ -31,6 +31,7 @@
 		<?php echo $title_for_layout;?> 
 		<?php __('for CakeBot: the best friend of irc'); ?>
 	</title>
+	<meta name="robots" content="noindex, nofollow">
 	<?php
 		echo $html->charset();
 		echo $html->meta('icon');


### PR DESCRIPTION
Some users have raised concerns about irclogs being accessible to search engines.